### PR TITLE
Correct find syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ for your new Python project.
 
 First run
 ```
-find . -type f -name "*.py" -o -name Makefile -o -name "*.yml" -print0 | xargs -0 sed -i 's/pyfoobar/your-project-name/g'
+find . -type f -print0 -name "*.py" -o -name Makefile -o -name "*.yml" | xargs -0 sed -i 's/pyfoobar/your-project-name/g'
 ```
 and rename the folder `pyfoobar` to customize the name.
 


### PR DESCRIPTION
Current `find . -type f -name "*.py" -o -name Makefile -o -name "*.yml" -print0` gives

```
./.circleci/config.yml ./.travis.yml ./codecov.yml
```

Need `find . -type f -print0 -name "*.py" -o -name Makefile -o -name "*.yml"`

```
./.circleci/config.yml ./.flake8 ./.gitignore ./.travis.yml ./codecov.yml ./CODE_OF_CONDUCT.md ./CONTRIBUTING.md ./LICENSE ./Makefile ./pyfoobar/cli.py ./pyfoobar/main.py ./pyfoobar/__about__.py ./pyfoobar/__init__.py ./README.md ./setup.py ./test/test_cli.py ./test/test_solve.py
```
