### PR TITLE
Enforce Python version via `python_requires`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,5 +38,6 @@ setup(
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Mathematics",
     ],
+    python_requires=">=3",
     entry_points={"console_scripts": ["pyfoobar-show = pyfoobar.cli:show"]},
 )


### PR DESCRIPTION
The Python versions indicated in `classifiers` are purely informative, we can use the recently introduced `python_requires` to enforce the required Python versions.

https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires